### PR TITLE
Adding configuration option to use only standard HTTP verbs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,6 +59,7 @@ module.exports = (config = {}) => {
   client.endpoint = config.endpoint || process.env.VAULT_ADDR || 'http://127.0.0.1:8200';
   client.pathPrefix = config.pathPrefix || process.env.VAULT_PREFIX || '';
   client.token = config.token || process.env.VAULT_TOKEN;
+  client.noCustomHTTPVerbs = config.noCustomHTTPVerbs || false;
 
   const requestSchema = {
     type: 'object',
@@ -118,8 +119,13 @@ module.exports = (config = {}) => {
   client.list = (path, requestOptions) => {
     debug(`list ${path}`);
     const options = Object.assign({}, config.requestOptions, requestOptions);
-    options.path = `/${path}`;
-    options.method = 'LIST';
+    if (client.noCustomHTTPVerbs) {
+      options.path = `/${path}?list=1`;
+      options.method = 'GET';
+    } else {
+      options.path = `/${path}`;
+      options.method = 'LIST';
+    }
     return client.request(options);
   };
 

--- a/test/unit.js
+++ b/test/unit.js
@@ -70,6 +70,7 @@ describe('node-vault', () => {
     let request = null;
     let response = null;
     let vault = null;
+    let vaultNoCustomVerbs = null;
 
     // helper
     function getURI(path) {
@@ -99,15 +100,17 @@ describe('node-vault', () => {
         },
       });
 
-      vault = index(
-        {
-          endpoint: 'http://localhost:8200',
-          token: '123',
-          'request-promise': {
-            defaults: () => request, // dependency injection of stub
-          },
-        }
-      );
+      const vaultConfig = {
+        endpoint: 'http://localhost:8200',
+        token: '123',
+        'request-promise': {
+          defaults: () => request, // dependency injection of stub
+        },
+      };
+
+      vault = index(vaultConfig);
+      vaultConfig.noCustomHTTPVerbs = true;
+      vaultNoCustomHTTPVerbs = index(vaultConfig);
     });
 
     describe('help(path, options)', () => {
@@ -135,15 +138,30 @@ describe('node-vault', () => {
     });
 
     describe('list(path, requestOptions)', () => {
-      it('should list entries at the specific path', done => {
-        const path = 'secret/hello';
-        const params = {
-          method: 'LIST',
-          uri: getURI(path),
-        };
-        vault.list(path)
-        .then(assertRequest(request, params, done))
-        .catch(done);
+      describe('with default options', () => {
+        it('should list entries at the specific path', done => {
+          const path = 'secret/hello';
+          const params = {
+            method: 'LIST',
+            uri: getURI(path),
+          };
+          vault.list(path)
+            .then(assertRequest(request, params, done))
+            .catch(done);
+        });
+      });
+
+      describe('with noCustomVerbs option', () => {
+        it('should list entries at the specific path', done => {
+          const path = 'secret/hello';
+          const params = {
+            method: 'GET',
+            uri: `${getURI(path)}?list=1`,
+          };
+          vaultNoCustomHTTPVerbs.list(path)
+            .then(assertRequest(request, params, done))
+            .catch(done);
+        });
       });
     });
 


### PR DESCRIPTION
Currently the client uses the LIST verb which is non-standard and unsupported by NodeJS. This allows a configuration option to use GET and append '?list=1' to the request instead.